### PR TITLE
Define MBEDTLS_PLATFORM_C under mingw - mettle #56

### DIFF
--- a/mbedtls-config.h
+++ b/mbedtls-config.h
@@ -77,6 +77,11 @@
 /* For testing with compat.sh */
 #define MBEDTLS_FS_IO
 
+/* For Windows */
+#ifdef _WIN32
+  #define MBEDTLS_PLATFORM_C
+#endif
+
 #include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
Fixes the following mess:
```
In file included from ../include/mbedtls/config.h:80:0,
                 from aes.c:29:
../include/mbedtls/check_config.h:43:2: error: #error "MBEDTLS_PLATFORM_C is required on Windows"
 #error "MBEDTLS_PLATFORM_C is required on Windows"
  ^~~~~
In file included from ../include/mbedtls/config.h:80:0,
                 from aes.c:29:
../include/mbedtls/check_config.h:355:2: error: #error "MBEDTLS_PLATFORM_SNPRINTF_ALT defined, but not all prerequisites"
 #error "MBEDTLS_PLATFORM_SNPRINTF_ALT defined, but not all prerequisites"
  ^~~~~
make[2]: *** [Makefile:162: aes.o] Error 1
make[1]: *** [Makefile:18: lib] Error 2
cp: cannot stat 'library/*.a': No such file or directory
```